### PR TITLE
File Metadata

### DIFF
--- a/prisma/migrations/20241216092450_add_file_metadata/migration.sql
+++ b/prisma/migrations/20241216092450_add_file_metadata/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `file_path` on the `File` table. All the data in the column will be lost.
+  - Added the required column `mimetype` to the `File` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `name` to the `File` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `path` to the `File` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `size` to the `File` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_File" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "mimetype" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "folder_id" INTEGER NOT NULL,
+    CONSTRAINT "File_folder_id_fkey" FOREIGN KEY ("folder_id") REFERENCES "folders" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_File" ("folder_id", "id") SELECT "folder_id", "id" FROM "File";
+DROP TABLE "File";
+ALTER TABLE "new_File" RENAME TO "File";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,10 @@ model Folder {
 
 model File {
     id        String @id
-    file_path String
+    name      String
+    size      Int
+    mimetype  String
+    path      String
     folder_id Int
 
     folder Folder @relation(fields: [folder_id], references: [id])

--- a/src/modules/files/files.service.ts
+++ b/src/modules/files/files.service.ts
@@ -56,7 +56,7 @@ export class FilesService {
             throw new UnauthorizedException();
         }
 
-        const fileStream = await this.bucket.streamFile(file.file_path);
+        const fileStream = await this.bucket.streamFile(file.path);
         return new StreamableFile(fileStream);
     }
 
@@ -75,7 +75,7 @@ export class FilesService {
         }
 
         const now = Date.now();
-        const fileName = `${now}_${file.filename}`;
+        const fileName = `${now}_${file.originalname}`;
         const hashedFileName = await this.bucket.createFile(fileName, file.buffer);
         if (!hashedFileName) {
             throw new InternalServerErrorException();
@@ -85,7 +85,10 @@ export class FilesService {
         return this.prisma.file.create({
             data: {
                 id: fileId,
-                file_path: hashedFileName,
+                name: file.originalname,
+                size: file.size,
+                mimetype: file.mimetype,
+                path: hashedFileName,
                 folder_id: folder.id,
             }
         });
@@ -113,7 +116,7 @@ export class FilesService {
             throw new InternalServerErrorException();
         }
 
-        await this.bucket.deleteFile(file.file_path);
+        await this.bucket.deleteFile(file.path);
         return file;
     }
 


### PR DESCRIPTION
## What?

Adds file metadata and closes #2.

## Why?

Storing files but not the metadata, like name, size, and mimetype, is like having many boxes but not knowing what is inside each. So, that is required to list all files and users be able to find out what they want.

## How?

Including file metadata in `File` model at Prisma.

```prisma
model File {
    id        String @id
    name      String
    size      Int
    mimetype  String
    path      String
    folder_id Int

    folder Folder @relation(fields: [folder_id], references: [id])
}
```