### PR TITLE
Storage Limit

### DIFF
--- a/prisma/migrations/20241216101351_add_user_storage_limit/migration.sql
+++ b/prisma/migrations/20241216101351_add_user_storage_limit/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_users" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "full_name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "storage_limit" INTEGER NOT NULL DEFAULT 524288000
+);
+INSERT INTO "new_users" ("email", "full_name", "id", "password") SELECT "email", "full_name", "id", "password" FROM "users";
+DROP TABLE "users";
+ALTER TABLE "new_users" RENAME TO "users";
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,10 +14,11 @@ datasource db {
 }
 
 model User {
-    id        Int    @id @default(autoincrement())
-    full_name String
-    email     String @unique
-    password  String
+    id            Int    @id @default(autoincrement())
+    full_name     String
+    email         String @unique
+    password      String
+    storage_limit Int    @default(524288000)
 
     sessions Session[]
     folders  Folder[]


### PR DESCRIPTION
## What?

Adds storage limit per account and closes #4.

## Why?

The server don't have an infinite amount of memory. Limit the total of memory each user can use is the basic. With that, we have the opportunity to have plans which increase the total.

## How?

Include the `storage_limit` directly into the `User` model with a default value of `500MB`. 

```prisma
model User {
    id            Int    @id @default(autoincrement())
    full_name     String
    email         String @unique
    password      String
    storage_limit Int    @default(524288000)

    sessions Session[]
    folders  Folder[]

    @@map("users")
}
```

When a user uploads a file, first it is validated if the new file doesn't exceed the usage. If so, it throws a `Forbidden` status; otherwhise, it is uploaded normally.

```js
if ((usedStorageSize + file.size) > user.storage_limit) {
    throw new ForbiddenException("you will exceed your maximum storage capacity.")
}
```